### PR TITLE
NeedsFuel Config Option for Driveables

### DIFF
--- a/src/main/java/com/flansmod/common/driveables/DriveableType.java
+++ b/src/main/java/com/flansmod/common/driveables/DriveableType.java
@@ -155,6 +155,10 @@ public class DriveableType extends PaintableType {
      * The fuel tank size
      */
     public int fuelTankSize = 100;
+    /**
+     * Whether the driveable requires fuel to run
+     */
+    public boolean needsFuel = true;
 
     //Rendering variables
     /**
@@ -654,6 +658,8 @@ public class DriveableType extends PaintableType {
                 numMissileSlots = Integer.parseInt(split[1]);
             else if (split[0].equals("FuelTankSize"))
                 fuelTankSize = Integer.parseInt(split[1]);
+  	    else if (split[0].equals("NeedsFuel"))
+                needsFuel = Boolean.parseBoolean(split[1]);
             else if (split[0].equals("EngineStartTime"))
                 engineStartTime = Integer.parseInt(split[1]);
             else if (split[0].equals("FilterAmmunitionInput"))

--- a/src/main/java/com/flansmod/common/driveables/EntityDriveable.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityDriveable.java
@@ -930,6 +930,12 @@ public abstract class EntityDriveable extends Entity implements IControllable, I
     }
 
     public boolean isEngineActive() {
+	if(getDriveableType().needsFuel == false) {
+    		driveableData.fuelInTank = 1;
+    	}
+    	if(getDriveableType().fuelTankSize <= 0) {
+    		getDriveableType().fuelTankSize = 1;
+    	}
         return (driverIsCreative() || driveableData.fuelInTank > 0) && engineStartDelay == 0;
     }
 

--- a/src/main/java/com/flansmod/common/driveables/EntityPlane.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityPlane.java
@@ -207,7 +207,7 @@ public class EntityPlane extends EntityDriveable {
             FlansMod.getPacketHandler().sendToServer(new PacketDriveableKey(key));
             return true;
         }
-        boolean canThrust = ((seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode) || getDriveableData().fuelInTank > 0) && isEngineActive();
+        boolean canThrust = ((seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode) || getDriveableData().fuelInTank > 0) && isEngineActive() || type.fuelTankSize <= 0;
         switch (key) {
             case 0: //Accelerate : Increase the throttle, up to 1.
             {

--- a/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
@@ -581,7 +581,7 @@ public class EntityVehicle extends EntityDriveable implements IExplodeable {
             //If the player driving this is in creative, then we can thrust, no matter what
             boolean canThrustCreatively = !TeamsManager.vehiclesNeedFuel || (seats != null && seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode);
             //Otherwise, check the fuel tanks!
-            if ((canThrustCreatively || data.fuelInTank > Math.abs(data.engine.fuelConsumption * throttle)) && isEngineActive()) {
+            if ((canThrustCreatively || type.fuelTankSize <= 0 || data.fuelInTank > Math.abs(data.engine.fuelConsumption * throttle)) && isEngineActive()) {
                 if (getVehicleType().tank) {
                     boolean left = wheel.ID == 0 || wheel.ID == 3;
 


### PR DESCRIPTION
## Description of changes
Added Config option for if the driveable needs fuel or not. (From trello board)
Has a roundabout way of doing it but gets the job done.
if enabled, fuel will always be in the tank
Has a small fail-safe if someone deliberately sets the tank size to 0 to avoid crashes
if tankSize is 0, tankSize=1

## Intended usage in Content Packs/Users of the mod
Manually powered vehicles/ "solar" powered vehicles that wouldnt need fuel in real life
e.i.
bicycles, skateboards. rickshaw, etc.

## Compatibility
shouldn,t break anything. new feature

## Other
in the future could have it also remove the fuel display when driving.
