### PR TITLE
FuelTankSize 0 or less to dsable fuel requirement

### DIFF
--- a/src/main/java/com/flansmod/common/driveables/EntityDriveable.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityDriveable.java
@@ -948,7 +948,7 @@ public abstract class EntityDriveable extends Entity implements IControllable, I
     }
 
     public boolean isEngineActive() {
-        return (driverIsCreative() || driveableData.fuelInTank > 0) && engineStartDelay == 0;
+        return (driverIsCreative() || driveableData.fuelInTank > 0) && engineStartDelay == 0 || getDriveableType().fuelTankSize <= 0;
     }
 
     public void correctWheelPos() {

--- a/src/main/java/com/flansmod/common/driveables/EntityDriveable.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityDriveable.java
@@ -948,7 +948,7 @@ public abstract class EntityDriveable extends Entity implements IControllable, I
     }
 
     public boolean isEngineActive() {
-        return (driverIsCreative() || driveableData.fuelInTank > 0) && engineStartDelay == 0 || getDriveableType().fuelTankSize <= 0;
+        return (driverIsCreative() || driveableData.fuelInTank > 0) && engineStartDelay == 0 || getDriveableType().fuelTankSize < 0;
     }
 
     public void correctWheelPos() {

--- a/src/main/java/com/flansmod/common/driveables/EntityPlane.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityPlane.java
@@ -207,7 +207,7 @@ public class EntityPlane extends EntityDriveable {
             FlansMod.getPacketHandler().sendToServer(new PacketDriveableKey(key));
             return true;
         }
-        boolean canThrust = ((seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode) || getDriveableData().fuelInTank > 0) && isEngineActive();
+        boolean canThrust = ((seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode) || getDriveableData().fuelInTank > 0) && isEngineActive() || type.fuelTankSize <= 0;
         switch (key) {
             case 0: //Accelerate : Increase the throttle, up to 1.
             {
@@ -590,7 +590,7 @@ public class EntityPlane extends EntityDriveable {
 
         //Movement
 
-        boolean canThrust = (seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode) || data.fuelInTank > 0;
+        boolean canThrust = (seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode) || data.fuelInTank > 0 || type.fuelTankSize <= o;
 
         //Throttle handling
         //Without a player, default to 0

--- a/src/main/java/com/flansmod/common/driveables/EntityPlane.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityPlane.java
@@ -207,7 +207,7 @@ public class EntityPlane extends EntityDriveable {
             FlansMod.getPacketHandler().sendToServer(new PacketDriveableKey(key));
             return true;
         }
-        boolean canThrust = ((seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode) || getDriveableData().fuelInTank > 0) && isEngineActive() || type.fuelTankSize <= 0;
+        boolean canThrust = ((seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode) || getDriveableData().fuelInTank > 0) && isEngineActive() || type.fuelTankSize < 0;
         switch (key) {
             case 0: //Accelerate : Increase the throttle, up to 1.
             {
@@ -590,7 +590,7 @@ public class EntityPlane extends EntityDriveable {
 
         //Movement
 
-        boolean canThrust = (seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode) || data.fuelInTank > 0 || type.fuelTankSize <= o;
+        boolean canThrust = (seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode) || data.fuelInTank > 0 || type.fuelTankSize < 0;
 
         //Throttle handling
         //Without a player, default to 0

--- a/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
@@ -581,7 +581,7 @@ public class EntityVehicle extends EntityDriveable implements IExplodeable {
             //If the player driving this is in creative, then we can thrust, no matter what
             boolean canThrustCreatively = !TeamsManager.vehiclesNeedFuel || (seats != null && seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode);
             //Otherwise, check the fuel tanks!
-            if ((canThrustCreatively || data.fuelInTank > Math.abs(data.engine.fuelConsumption * throttle)) && isEngineActive()) {
+            if ((canThrustCreatively || type.fuelTankSize <= 0 || data.fuelInTank > Math.abs(data.engine.fuelConsumption * throttle)) && isEngineActive()) {
                 if (getVehicleType().tank) {
                     boolean left = wheel.ID == 0 || wheel.ID == 3;
 

--- a/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
@@ -579,9 +579,9 @@ public class EntityVehicle extends EntityDriveable implements IExplodeable {
 
             //Apply velocity
             //If the player driving this is in creative, then we can thrust, no matter what
-            boolean canThrustCreatively = !TeamsManager.vehiclesNeedFuel || (seats != null && seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode);
+            boolean canThrustCreatively = !TeamsManager.vehiclesNeedFuel || type.fuelTankSize <= 0 || (seats != null && seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode);
             //Otherwise, check the fuel tanks!
-            if ((canThrustCreatively || data.fuelInTank > Math.abs(data.engine.fuelConsumption * throttle)) && isEngineActive()) {
+            if ((canThrustCreatively || type.fuelTankSize <= 0 || data.fuelInTank > Math.abs(data.engine.fuelConsumption * throttle)) && isEngineActive()) {
                 if (getVehicleType().tank) {
                     boolean left = wheel.ID == 0 || wheel.ID == 3;
 

--- a/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
@@ -579,9 +579,9 @@ public class EntityVehicle extends EntityDriveable implements IExplodeable {
 
             //Apply velocity
             //If the player driving this is in creative, then we can thrust, no matter what
-            boolean canThrustCreatively = !TeamsManager.vehiclesNeedFuel || type.fuelTankSize <= 0 || (seats != null && seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode);
+            boolean canThrustCreatively = !TeamsManager.vehiclesNeedFuel || type.fuelTankSize < 0 || (seats != null && seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode);
             //Otherwise, check the fuel tanks!
-            if ((canThrustCreatively || type.fuelTankSize <= 0 || data.fuelInTank > Math.abs(data.engine.fuelConsumption * throttle)) && isEngineActive()) {
+            if ((canThrustCreatively || type.fuelTankSize < 0 || data.fuelInTank > Math.abs(data.engine.fuelConsumption * throttle)) && isEngineActive()) {
                 if (getVehicleType().tank) {
                     boolean left = wheel.ID == 0 || wheel.ID == 3;
 

--- a/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
@@ -581,7 +581,7 @@ public class EntityVehicle extends EntityDriveable implements IExplodeable {
             //If the player driving this is in creative, then we can thrust, no matter what
             boolean canThrustCreatively = !TeamsManager.vehiclesNeedFuel || (seats != null && seats[0] != null && seats[0].riddenByEntity instanceof EntityPlayer && ((EntityPlayer) seats[0].riddenByEntity).capabilities.isCreativeMode);
             //Otherwise, check the fuel tanks!
-            if ((canThrustCreatively || type.fuelTankSize <= 0 || data.fuelInTank > Math.abs(data.engine.fuelConsumption * throttle)) && isEngineActive()) {
+            if ((canThrustCreatively || data.fuelInTank > Math.abs(data.engine.fuelConsumption * throttle)) && isEngineActive()) {
                 if (getVehicleType().tank) {
                     boolean left = wheel.ID == 0 || wheel.ID == 3;
 


### PR DESCRIPTION
## Description of changes
Made it so driveables can function w/o fuel if their tank size is 0 or less

## Intended usage in Content Packs/Users of the mod
manual/solar vehicles.

## Compatibility
No breakages ive found

## Other
Tested, works for both vehicles and planes w/o affecting performance.
