### PR TITLE
Fix smol hitbox planes from not appearing

### DIFF
--- a/src/main/java/com/flansmod/common/driveables/EntityDriveable.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityDriveable.java
@@ -212,7 +212,7 @@ public abstract class EntityDriveable extends Entity implements IControllable, I
         if (FlansMod.driveableHitboxes) {
             setSize(1F, 1F);
         } else {
-            setSize(0.0F, 0.0F);
+            setSize(0.0005F, 0.0005F);
         }
         yOffset = 6F / 16F;
         ignoreFrustumCheck = true;


### PR DESCRIPTION
## Description of changes
Changed hitbox size when disabled vehicle hitboxes in `flansmod.cfg` from 0x0 to 0.0005x0.0005 to prevent planes from disappearing.

## Intended usage in Content Packs/Users of the mod
No change/fix.
Original feature is to prevent glitching with hitboxes.

## Compatibility
Likely nothing.

## Other
Future goal: Work out exactly why planes were invisible and vehicles were visible.
