### PR TITLE
Fix smol hitbox planes from not appearing (2)

### DIFF
--- a/src/main/java/com/flansmod/common/driveables/EntityDriveable.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityDriveable.java
@@ -212,7 +212,7 @@ public abstract class EntityDriveable extends Entity implements IControllable, I
         if (FlansMod.driveableHitboxes) {
             setSize(1F, 1F);
         } else {
-            setSize(0.0005F, 0.0005F);
+            setSize(0F, 0F);
         }
         yOffset = 6F / 16F;
         ignoreFrustumCheck = true;
@@ -2791,8 +2791,15 @@ public abstract class EntityDriveable extends Entity implements IControllable, I
             recoilTimer = (int) getDriveableType().shootDelayPrimary;
     }
 
+    @Override
+    public boolean isInRangeToRenderDist(double d) {
+        double d1 = this.renderDistanceWeight;
+        return d < d1 * d1;
+    }
+
     // Returns if the bounding box is under the 
     public boolean isUnderWater() {
         return worldObj.isAnyLiquid(this.boundingBox.copy().offset(0, getDriveableType().maxDepth, 0));
     }
 }
+

--- a/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
@@ -180,12 +180,6 @@ public class EntityVehicle extends EntityDriveable implements IExplodeable {
         varDoor = tag.getBoolean("VarDoor");
     }
 
-    @Override
-    public boolean isInRangeToRenderDist(double d) {
-        double d1 = 400D;
-        return d < d1 * d1;
-    }
-
     /**
      * Called with the movement of the mouse. Used in controlling vehicles if need be.
      *


### PR DESCRIPTION
## Description of changes
Overridden standard render distance method for EntityDriveable that was present in EntityVehicle before. Ignores hitbox size, allowing proper 0x0 hitbox sizes.

## Intended usage in Content Packs/Users of the mod
~

## Compatibility
~

## Other
PR is for hacktoberfest contributions ;)
