### PR TITLE
3rd person camera stabilization.

### DIFF
--- a/src/main/java/com/flansmod/client/EntityCamera.java
+++ b/src/main/java/com/flansmod/client/EntityCamera.java
@@ -45,9 +45,7 @@ public class EntityCamera extends EntityLivingBase
 		double dY = driveable.posY + cameraPosition.y - posY;
 		double dZ = driveable.posZ + cameraPosition.z - posZ;
 		
-		float lerpAmount = 0.1F;
-		
-		setPosition(posX + dX * lerpAmount, posY + dY * lerpAmount, posZ + dZ * lerpAmount);
+		setPosition(posX + dX, posY + dY, posZ + dZ);
 		
 		if(FlansMod.proxy.mouseControlEnabled())
 			{


### PR DESCRIPTION
Removes that zoom out effect when speeding up. makes third person camera more like other games as ace combat and war thunder. Now when mouse control is disabled, you can properly look around the vehicle. Thus allowing for the "CameraDistance" variable to be true even when not sitting still.