### PR TITLE
[Minigames] bugfix

### DIFF
--- a/src/main/java/com/flansmod/common/teams/GameTypeCTF.java
+++ b/src/main/java/com/flansmod/common/teams/GameTypeCTF.java
@@ -302,20 +302,22 @@ public class GameTypeCTF extends GameType
 	@Override
 	public Vec3 getSpawnPoint(EntityPlayerMP player) 
 	{
-		if(teamsManager.currentRound == null)
+		if(teamsManager.currentRound == null) {
 			return null;
+		}
 		PlayerData data = getPlayerData(player);
 		List<ITeamObject> validSpawnPoints = new ArrayList<ITeamObject>();
-		if(data.newTeam == null)
+		if(data.newTeam == null){
 			return null;
+		}
 		
 		ArrayList<ITeamBase> bases = teamsManager.currentRound.map.getBasesPerTeam(teamsManager.currentRound.getTeamID(data.newTeam));
 		for (ITeamBase base : bases) {
-			if (base.getMap() != teamsManager.currentRound.map)
-				continue;
-			for (int i = 0; i < base.getObjects().size(); i++) {
-				if (base.getObjects().get(i).isSpawnPoint())
-					validSpawnPoints.add(base.getObjects().get(i));
+			if (base.getMap().equals(teamsManager.currentRound.map)) {
+				for (int i = 0; i < base.getObjects().size(); i++) {
+					if (base.getObjects().get(i).isSpawnPoint())
+						validSpawnPoints.add(base.getObjects().get(i));
+				}
 			}
 		}
 		
@@ -324,7 +326,6 @@ public class GameTypeCTF extends GameType
 			ITeamObject spawnPoint = validSpawnPoints.get(rand.nextInt(validSpawnPoints.size()));
 			return Vec3.createVectorHelper(spawnPoint.getPosX(), spawnPoint.getPosY(), spawnPoint.getPosZ());
 		}
-		
 		return null;
 	}
 

--- a/src/main/java/com/flansmod/common/teams/GameTypeDM.java
+++ b/src/main/java/com/flansmod/common/teams/GameTypeDM.java
@@ -172,52 +172,46 @@ public class GameTypeDM extends GameType
 		
 	}
 
-	@Override
-	public Vec3 getSpawnPoint(EntityPlayerMP player) 
-	{
-		if(teamsManager.currentRound == null)
-			return null;
-		PlayerData data = getPlayerData(player);
-		List<ITeamObject> validSpawnPoints = new ArrayList<ITeamObject>();
-		if(data.newTeam == null)
-			return null;
-		
-		//Check each team's spawnpoints
-		if(data.newTeam == Team.spectators)
-		{
-			ArrayList<ITeamBase> bases = teamsManager.currentRound.map.getBasesPerTeam(teamsManager.currentRound.getTeamID(data.newTeam));
-			for (ITeamBase base : bases) {
-				if (base.getMap() != teamsManager.currentRound.map)
-					continue;
-				for (int i = 0; i < base.getObjects().size(); i++) {
-					if (base.getObjects().get(i).isSpawnPoint())
-						validSpawnPoints.add(base.getObjects().get(i));
-				}
-			}
-		}
-		else
-		{
-			for(int k = 2; k < 4; k++)
-			{
-				ArrayList<ITeamBase> bases = teamsManager.currentRound.map.getBasesPerTeam(k);
-				for (ITeamBase base : bases) {
-					if (base.getMap() != teamsManager.currentRound.map)
-						continue;
-					for (int i = 0; i < base.getObjects().size(); i++) {
-						if (base.getObjects().get(i).isSpawnPoint())
-							validSpawnPoints.add(base.getObjects().get(i));
-					}
-				}
-			}
-		}
-		if(validSpawnPoints.size() > 0)
-		{
-			ITeamObject spawnPoint = validSpawnPoints.get(rand.nextInt(validSpawnPoints.size()));
-			return Vec3.createVectorHelper(spawnPoint.getPosX(), spawnPoint.getPosY(), spawnPoint.getPosZ());
-		}
-		
-		return null;
-	}
+        @Override
+        public Vec3 getSpawnPoint(EntityPlayerMP player) {
+        if (teamsManager.currentRound == null)
+            return null;
+        PlayerData data = getPlayerData(player);
+        List<ITeamObject> validSpawnPoints = new ArrayList<ITeamObject>();
+        if (data.newTeam == null)
+            return null;
+
+        //Check each team's spawnpoints
+        if (data.newTeam == Team.spectators) {
+            ArrayList<ITeamBase> bases = teamsManager.currentRound.map.getBasesPerTeam(teamsManager.currentRound.getTeamID(data.newTeam));
+            for (ITeamBase base : bases) {
+                if (base.getMap().equals(teamsManager.currentRound.map)) {
+                    for (int i = 0; i < base.getObjects().size(); i++) {
+                        if (base.getObjects().get(i).isSpawnPoint())
+                            validSpawnPoints.add(base.getObjects().get(i));
+                    }
+                }
+            }
+        } else {
+            for (int k = 2; k < 4; k++) {
+                ArrayList<ITeamBase> bases = teamsManager.currentRound.map.getBasesPerTeam(k);
+                for (ITeamBase base : bases) {
+                    if (base.getMap() != teamsManager.currentRound.map)
+                        continue;
+                    for (int i = 0; i < base.getObjects().size(); i++) {
+                        if (base.getObjects().get(i).isSpawnPoint())
+                            validSpawnPoints.add(base.getObjects().get(i));
+                    }
+                }
+            }
+        }
+        if (validSpawnPoints.size() > 0) {
+            ITeamObject spawnPoint = validSpawnPoints.get(rand.nextInt(validSpawnPoints.size()));
+            return Vec3.createVectorHelper(spawnPoint.getPosX(), spawnPoint.getPosY(), spawnPoint.getPosZ());
+        }
+
+        return null;
+        }
 
 	@Override
 	public void playerRespawned(EntityPlayerMP player) 

--- a/src/main/java/com/flansmod/common/teams/GameTypeTDM.java
+++ b/src/main/java/com/flansmod/common/teams/GameTypeTDM.java
@@ -211,31 +211,34 @@ public class GameTypeTDM extends GameType {
     }
 
     @Override
-    public Vec3 getSpawnPoint(EntityPlayerMP player) {
-        if (teamsManager.currentRound == null)
-            return null;
-        PlayerData data = getPlayerData(player);
-        List<ITeamObject> validSpawnPoints = new ArrayList<ITeamObject>();
-        if (data.newTeam == null)
-            return null;
-
-        ArrayList<ITeamBase> bases = teamsManager.currentRound.map.getBasesPerTeam(teamsManager.currentRound.getTeamID(data.newTeam));
-        for (ITeamBase base : bases) {
-            if (base.getMap() != teamsManager.currentRound.map)
-                continue;
-            for (int i = 0; i < base.getObjects().size(); i++) {
-                if (base.getObjects().get(i).isSpawnPoint())
-                    validSpawnPoints.add(base.getObjects().get(i));
-            }
-        }
-
-        if (validSpawnPoints.size() > 0) {
-            ITeamObject spawnPoint = validSpawnPoints.get(rand.nextInt(validSpawnPoints.size()));
-            return Vec3.createVectorHelper(spawnPoint.getPosX(), spawnPoint.getPosY(), spawnPoint.getPosZ());
-        }
-
-        return null;
-    }
+	public Vec3 getSpawnPoint(EntityPlayerMP player) 
+	{
+		if(teamsManager.currentRound == null) {
+			return null;
+		}
+		PlayerData data = getPlayerData(player);
+		List<ITeamObject> validSpawnPoints = new ArrayList<ITeamObject>();
+		if(data.newTeam == null){
+			return null;
+		}
+		
+		ArrayList<ITeamBase> bases = teamsManager.currentRound.map.getBasesPerTeam(teamsManager.currentRound.getTeamID(data.newTeam));
+		for (ITeamBase base : bases) {
+			if (base.getMap().equals(teamsManager.currentRound.map)) {
+				for (int i = 0; i < base.getObjects().size(); i++) {
+					if (base.getObjects().get(i).isSpawnPoint())
+						validSpawnPoints.add(base.getObjects().get(i));
+				}
+			}
+		}
+		
+		if(validSpawnPoints.size() > 0)
+		{
+			ITeamObject spawnPoint = validSpawnPoints.get(rand.nextInt(validSpawnPoints.size()));
+			return Vec3.createVectorHelper(spawnPoint.getPosX(), spawnPoint.getPosY(), spawnPoint.getPosZ());
+		}
+		return null;
+	}
 
     @Override
     public void playerRespawned(EntityPlayerMP player) {

--- a/src/main/java/com/flansmod/common/teams/TeamsManager.java
+++ b/src/main/java/com/flansmod/common/teams/TeamsManager.java
@@ -1009,12 +1009,12 @@ public class TeamsManager {
         }
 
         //Preload each gun
-        for (int i = 0; i < player.inventory.getSizeInventory(); i++) {
-            ItemStack stack = player.inventory.getStackInSlot(i);
-            if (stack != null && stack.getItem() instanceof ItemGun) {
-                ((ItemGun) stack.getItem()).reload(stack, ((ItemGun) stack.getItem()).type, player.worldObj, player, true, false);
-            }
-        }
+//         for (int i = 0; i < player.inventory.getSizeInventory(); i++) {
+//             ItemStack stack = player.inventory.getStackInSlot(i);
+//             if (stack != null && stack.getItem() instanceof ItemGun) {
+//                 ((ItemGun) stack.getItem()).reload(stack, ((ItemGun) stack.getItem()).type, player.worldObj, player, true, false);
+//             }
+//         }
     }
 
     //---------------------------------------------------------


### PR DESCRIPTION
**respawn bugfix**
if the server had more than 1 map with its own spawns, then the player respawned at the spawn points of only the first map or even remained in place
**disconect fix**
this function did not work before, but with the advent of the selective reload function, an error occurs (for an unknown reason, if the ItemGun#reload function is called from here, the ItemGun.type.ammo[] array is empty