### PR TITLE
Add mecha legs to vehicles

### DIFF
--- a/src/main/java/com/flansmod/client/model/ModelVehicle.java
+++ b/src/main/java/com/flansmod/client/model/ModelVehicle.java
@@ -27,6 +27,11 @@ public class ModelVehicle extends ModelDriveable {
     public ModelRendererTurbo[] rightTrackWheelModels = new ModelRendererTurbo[0];    //These go with the tracks but rotate
     public ModelRendererTurbo[] leftTrackWheelModels = new ModelRendererTurbo[0];
 
+    public ModelRendererTurbo[] leftFrontLegModel = new ModelRendererTurbo[0];
+    public ModelRendererTurbo[] rightFrontLegModel = new ModelRendererTurbo[0];
+    public ModelRendererTurbo[] leftBackLegModel = new ModelRendererTurbo[0];
+    public ModelRendererTurbo[] rightBackLegModel = new ModelRendererTurbo[0];
+
     public ModelRendererTurbo[][] leftAnimTrackModel = new ModelRendererTurbo[0][0];  //Unlimited frame track animations
     public ModelRendererTurbo[][] rightAnimTrackModel = new ModelRendererTurbo[0][0];
 
@@ -85,6 +90,23 @@ public class ModelVehicle extends ModelDriveable {
     public boolean fancyTurret = false;
     public String turretName;
 
+    // Leg stuff: Animation variables
+
+    // Multiplier for the speed of leg movement
+    public float legMoveSpeed = 1F;
+    // Multiplier for the maximum angle of leg movement
+    public float legMaxMove = 1F;
+    // Used for steering, decides how much the legs on l/r should speed up or slow down when turning.
+    public float legSteerAmount = 1F;
+    // Change speed of leg movement depending on throttle
+    public boolean legSpeedChange = true;
+
+    // Leg stuff: Animation state
+    private float lastRelSpeedRight = 0F;
+    private float lastRelSpeedLeft = 0F;
+
+    private float legAnimPosRight = 0;
+    private float legAnimPosLeft = 0;
 
     @Override
     public void render(EntityDriveable driveable, float f1) {
@@ -104,6 +126,10 @@ public class ModelVehicle extends ModelDriveable {
         renderPart(rightFrontWheelModel);
         renderPart(rightTrackModel);
         renderPart(leftTrackModel);
+        renderPart(leftFrontLegModel);
+        renderPart(rightFrontLegModel);
+        renderPart(leftBackLegModel);
+        renderPart(rightBackLegModel);
         renderPart(rightTrackWheelModels);
         renderPart(leftTrackWheelModels);
         renderPart(bodyDoorCloseModel);
@@ -215,11 +241,36 @@ public class ModelVehicle extends ModelDriveable {
         animFrameLeft = vehicle.animFrameLeft;
         animFrameRight = vehicle.animFrameRight;
 
+        float bias = 0.1F;
+        lastRelSpeedRight = (lastRelSpeedRight * (1 - bias)) + (float)(((legSpeedChange ? vehicle.throttle : 1F) * (1 - (vehicle.wheelsYaw / 20F) * legSteerAmount)) * bias);
+        lastRelSpeedLeft = (lastRelSpeedLeft * (1 - bias)) + (float)(((legSpeedChange ? vehicle.throttle : 1F) * (1 + (vehicle.wheelsYaw / 20F) * legSteerAmount)) * bias);
+
+        float scaleRight = lastRelSpeedRight;
+        float scaleLeft = lastRelSpeedLeft;
+        float adjScaleRight = Math.signum(scaleRight) * 0.4F + 0.6F * scaleRight * scaleRight;
+        float adjScaleLeft = Math.signum(scaleLeft) * 0.4F + 0.6F * scaleLeft * scaleLeft;
+
+        scaleRight = (float)Math.sqrt(Math.abs(scaleRight));
+        scaleLeft = (float)Math.sqrt(Math.abs(scaleLeft));
+
+        scaleRight = scaleRight > 0.01 ? scaleRight : 0;
+        scaleLeft = scaleLeft > 0.01 ? scaleLeft : 0;
+
+        legAnimPosRight += adjScaleRight * f;
+        legAnimPosLeft += adjScaleLeft * f;
+
+        float frLegYaw = (float)Math.sin((legAnimPosRight + 3.14 * 0.5) * legMoveSpeed) * scaleRight * legMaxMove;
+        float brLegYaw = (float)Math.sin((legAnimPosRight + 3.14 * 1.5) * legMoveSpeed) * scaleRight * legMaxMove;
+
+        float flLegYaw = (float)Math.sin((legAnimPosLeft) * legMoveSpeed) * scaleLeft * legMaxMove;
+        float blLegYaw = (float)Math.sin((legAnimPosLeft) * legMoveSpeed) * scaleLeft * legMaxMove;
+
         //Rendering the body
         if (vehicle.isPartIntact(EnumDriveablePart.core)) {
             for (ModelRendererTurbo aBodyModel : bodyModel) {
                 aBodyModel.render(f5, oldRotateOrder);
             }
+
             for (ModelRendererTurbo aBodyDoorOpenModel : bodyDoorOpenModel) {
                 if (vehicle.varDoor)
                     aBodyDoorOpenModel.render(f5, oldRotateOrder);
@@ -242,11 +293,21 @@ public class ModelVehicle extends ModelDriveable {
                 aLeftBackWheelModel.rotateAngleZ = rotateWheels ? -vehicle.wheelsAngle : 0;
                 aLeftBackWheelModel.render(f5, oldRotateOrder);
             }
+
+            for (ModelRendererTurbo aLeftBackLegModel : leftBackLegModel) {
+                aLeftBackLegModel.rotateAngleZ = blLegYaw * 3.14159265F / 2.5F;
+                aLeftBackLegModel.render(f5, oldRotateOrder);
+            }
         }
         if (vehicle.isPartIntact(EnumDriveablePart.backRightWheel)) {
             for (ModelRendererTurbo aRightBackWheelModel : rightBackWheelModel) {
                 aRightBackWheelModel.rotateAngleZ = rotateWheels ? -vehicle.wheelsAngle : 0;
                 aRightBackWheelModel.render(f5, oldRotateOrder);
+            }
+
+            for (ModelRendererTurbo aRightBackLegModel : rightBackLegModel) {
+                aRightBackLegModel.rotateAngleZ = brLegYaw * 3.14159265F / 2.5F;
+                aRightBackLegModel.render(f5, oldRotateOrder);
             }
         }
         if (vehicle.isPartIntact(EnumDriveablePart.frontLeftWheel)) {
@@ -255,12 +316,22 @@ public class ModelVehicle extends ModelDriveable {
                 aLeftFrontWheelModel.rotateAngleY = -vehicle.wheelsYaw * 3.14159265F / 180F * 3F;
                 aLeftFrontWheelModel.render(f5, oldRotateOrder);
             }
+
+            for (ModelRendererTurbo aLeftFrontLegModel : leftFrontLegModel) {
+                aLeftFrontLegModel.rotateAngleZ = flLegYaw * 3.14159265F / 2.5F;
+                aLeftFrontLegModel.render(f5, oldRotateOrder);
+            }
         }
         if (vehicle.isPartIntact(EnumDriveablePart.frontRightWheel)) {
             for (ModelRendererTurbo aRightFrontWheelModel : rightFrontWheelModel) {
                 aRightFrontWheelModel.rotateAngleZ = rotateWheels ? -vehicle.wheelsAngle : 0;
                 aRightFrontWheelModel.rotateAngleY = -vehicle.wheelsYaw * 3.14159265F / 180F * 3F;
                 aRightFrontWheelModel.render(f5, oldRotateOrder);
+            }
+
+            for (ModelRendererTurbo aRightFrontLegModel : rightFrontLegModel) {
+                aRightFrontLegModel.rotateAngleZ = frLegYaw * 3.14159265F / 2.5F;
+                aRightFrontLegModel.render(f5, oldRotateOrder);
             }
         }
         if (vehicle.isPartIntact(EnumDriveablePart.frontWheel)) {
@@ -599,6 +670,10 @@ public class ModelVehicle extends ModelDriveable {
         flip(rightFrontWheelModel);
         flip(leftBackWheelModel);
         flip(rightBackWheelModel);
+        flip(rightFrontLegModel);
+        flip(leftFrontLegModel);
+        flip(rightBackLegModel);
+        flip(leftBackLegModel);
         flip(rightTrackModel);
         flip(leftTrackModel);
         flip(rightTrackWheelModels);
@@ -641,6 +716,10 @@ public class ModelVehicle extends ModelDriveable {
         translate(rightFrontWheelModel, x, y, z);
         translate(leftBackWheelModel, x, y, z);
         translate(rightBackWheelModel, x, y, z);
+        translate(leftFrontLegModel, x, y, z);
+        translate(rightFrontLegModel, x, y, z);
+        translate(leftBackLegModel, x, y, z);
+        translate(rightBackLegModel, x, y, z);
         translate(rightTrackModel, x, y, z);
         translate(leftTrackModel, x, y, z);
         translate(rightTrackWheelModels, x, y, z);


### PR DESCRIPTION
## Description of changes
Added new leg part groups to vehicles, similar to mecha legs.
These legs animate back and forth, increasing frequency and angle depending on vehicle throttle.
Several parameters are available, to be explained in the wiki.

## Intended usage in Content Packs/Users of the mod
For (vehicles?) more suited to being implemented as vehicles, IE moving platforms with legs and turrets instead of traditional mecha type stuff.

## Compatibility
No - this content is all new and has no conflicts that I'm aware of.
