### PR TITLE
Adds easyArms setting to make setting up arms easier

### DIFF
--- a/src/main/java/com/flansmod/client/model/ModelGun.java
+++ b/src/main/java/com/flansmod/client/model/ModelGun.java
@@ -60,6 +60,8 @@ public class ModelGun extends ModelBase
 
 	//Arms rendering
 	public boolean hasArms = false;
+	//Changes the rotation point to be the hand for easier animation setup
+	public boolean easyArms = false;
 	public Vector3f leftArmPos = new Vector3f(0,0,0);
 	public Vector3f leftArmRot = new Vector3f(0,0,0);
 	public Vector3f leftArmScale = new Vector3f(1,1,1);

--- a/src/main/java/com/flansmod/client/model/ModelGun.java
+++ b/src/main/java/com/flansmod/client/model/ModelGun.java
@@ -62,6 +62,8 @@ public class ModelGun extends ModelBase
 	public boolean hasArms = false;
 	//Changes the rotation point to be the hand for easier animation setup
 	public boolean easyArms = false;
+	public Vector3f armScale = new Vector3f(0.8F,0.8F,0.8F);
+
 	public Vector3f leftArmPos = new Vector3f(0,0,0);
 	public Vector3f leftArmRot = new Vector3f(0,0,0);
 	public Vector3f leftArmScale = new Vector3f(1,1,1);

--- a/src/main/java/com/flansmod/client/model/RenderArms.java
+++ b/src/main/java/com/flansmod/client/model/RenderArms.java
@@ -12,14 +12,14 @@ public class RenderArms {
 		GL11.glTranslatef(-(armPosition.x
 				- Math.abs(anim.lastPumped + (anim.pumped - anim.lastPumped) * smoothing) / model.pumpModifier),
 				armPosition.y, armPosition.z);
-		handleRotate(rotationPoint);
+		handleRotate(rotationPoint, model);
 	}
 	
 	// This moves the right hand if leftHandAmmo & handCharge are true (For left
 	// hand reload with right hand charge)
 	public static void renderArmCharge(ModelGun model, GunAnimations anim, float smoothing, Vector3f rotationPoint, Vector3f armPosition)
 	{
-		handleRotate(rotationPoint);
+		handleRotate(rotationPoint, model);
 		GL11.glTranslatef(
 				-(armPosition.x
 						- Math.abs(anim.lastCharged + (anim.charged - anim.lastCharged) * smoothing)
@@ -36,7 +36,7 @@ public class RenderArms {
 	// reload with right hand bolt action)
 	public static void renderArmBolt(ModelGun model, GunAnimations anim, float smoothing, Vector3f rotationPoint, Vector3f armPosition)
 	{
-		handleRotate(rotationPoint);
+		handleRotate(rotationPoint, model);
 		GL11.glTranslatef(
 				(armPosition.x + Math.abs(anim.lastPumped + (anim.pumped - anim.lastPumped) * smoothing)
 						/ model.chargeModifier.x),
@@ -50,21 +50,25 @@ public class RenderArms {
 	
 	public static void renderArmDefault(ModelGun model, GunAnimations anim, float smoothing, Vector3f rotationPoint, Vector3f armPosition)
 	{
-		handleRotate(rotationPoint);
+		handleRotate(rotationPoint, model);
 		GL11.glTranslatef(armPosition.x, armPosition.y, armPosition.z);
 	}
 	
 	public static void renderArmReload(ModelGun model, GunAnimations anim, float smoothing, Vector3f rotationPoint, Vector3f armPosition)
 	{
-		handleRotate(rotationPoint);
+		handleRotate(rotationPoint, model);
 		GL11.glTranslatef(armPosition.x, armPosition.y, armPosition.z);
 	}
 	
-	private static void handleRotate(Vector3f rotationPoint)
+	private static void handleRotate(Vector3f rotationPoint, ModelGun model)
 	{
+		if (model.easyArms)
+			GL11.glTranslatef(+0.4F * 0.8F, +0.75F * 0.8F, -0F * 0.8F);
 		GL11.glRotatef(rotationPoint.y, 0F, 1F, 0F);
 		GL11.glRotatef(rotationPoint.z, 0F, 0F, 1F);
 		GL11.glRotatef(rotationPoint.x, 1F, 0F, 0F);
+		if (model.easyArms)
+			GL11.glTranslatef(-0.4F * 0.8F, -0.75F * 0.8F, +0F * 0.8F);
 	}
 
 }

--- a/src/main/java/com/flansmod/client/model/RenderArms.java
+++ b/src/main/java/com/flansmod/client/model/RenderArms.java
@@ -63,12 +63,12 @@ public class RenderArms {
 	private static void handleRotate(Vector3f rotationPoint, ModelGun model)
 	{
 		if (model.easyArms)
-			GL11.glTranslatef(+0.4F * 0.8F, +0.75F * 0.8F, -0F * 0.8F);
+			GL11.glTranslatef(+0.4F * model.armScale.getX(), +0.75F * model.armScale.getY(), -0F * model.armScale.getZ());
 		GL11.glRotatef(rotationPoint.y, 0F, 1F, 0F);
 		GL11.glRotatef(rotationPoint.z, 0F, 0F, 1F);
 		GL11.glRotatef(rotationPoint.x, 1F, 0F, 0F);
 		if (model.easyArms)
-			GL11.glTranslatef(-0.4F * 0.8F, -0.75F * 0.8F, +0F * 0.8F);
+			GL11.glTranslatef(-0.4F * model.armScale.getX(), -0.75F * model.armScale.getY(), +0F * model.armScale.getZ());
 	}
 
 }

--- a/src/main/java/com/flansmod/common/guns/GunType.java
+++ b/src/main/java/com/flansmod/common/guns/GunType.java
@@ -902,6 +902,11 @@ public class GunType extends PaintableType implements IScope {
             model.hasFlash = Boolean.parseBoolean(split[1]);
         else if (split[0].equals("animHasArms"))
             model.hasArms = Boolean.parseBoolean(split[1]);
+        else if (split[0].equals("easyArms"))
+            model.easyArms = Boolean.parseBoolean(split[1]);
+        else if (split[0].equals("armScale"))
+            model.armScale = parseVector3f(split);
+
 
         else if (split[0].equals("animLeftArmPos"))
             model.leftArmPos = parseVector3f(split);


### PR DESCRIPTION
## Description of changes
This adds an "easyArms" setting into gun models which will set the rotation point of arms to be the hands. This makes setting up arm animations much easier. Must be used alongside armScale (or it will use the default scale). Should not be used with leftArmScale/rightArmScale. These should get deprecated tbh.

## Intended usage in Content Packs/Users of the mod
Intended for content creators

## Compatibility
No breaking changes

