### PR TITLE
added bullet damage modifiers

### DIFF
--- a/src/main/java/com/flansmod/common/guns/BulletType.java
+++ b/src/main/java/com/flansmod/common/guns/BulletType.java
@@ -48,6 +48,16 @@ public class BulletType extends ShootableType
 	public float penetratingPower = 1F;
 	// In % of penetration to remove per tick.
 	public float penetrationDecay = 0F;
+	
+	/*
+	 * How much the loss of penetration power affects the damage of the bullet. 0 = damage not affected by that kind of penetration, 
+	 * 1 = damage is fully affected by bullet penetration of that kind
+	 */
+	public float playerPenetrationEffectOnDamage = 0F;
+	public float entityPenetrationEffectOnDamage = 0F;
+	public float blockPenetrationEffectOnDamage = 0F;
+	public float penetrationDecayEffectOnDamage = 0F;
+	
 	// Knocback modifier. less gives less kb, more gives more kb, 1 = normal kb.
 	public float knockbackModifier;
 	/** Lock on variables. If true, then the bullet will search for a target at the moment it is fired */
@@ -159,6 +169,16 @@ public class BulletType extends ShootableType
 				penetratingPower = Float.parseFloat(split[1]);
 			else if(split[0].equals("PenetrationDecay"))
 				penetrationDecay = Float.parseFloat(split[1]);
+						
+			else if(split[0].equals("PlayerPenetrationDamageEffect"))
+				playerPenetrationEffectOnDamage = Float.parseFloat(split[1]);
+			else if(split[0].equals("EntityPenetrationDamageEffect"))
+				entityPenetrationEffectOnDamage = Float.parseFloat(split[1]);
+			else if(split[0].equals("BlockPenetrationDamageEffect"))
+				blockPenetrationEffectOnDamage = Float.parseFloat(split[1]);
+			else if(split[0].equals("PenetrationDecayDamageEffect"))
+				penetrationDecayEffectOnDamage = Float.parseFloat(split[1]);
+			
 			else if(split[0].equals("DragInAir"))
 			{
 				dragInAir = Float.parseFloat(split[1]);
@@ -285,7 +305,22 @@ public class BulletType extends ShootableType
 			}
 		}
 	}
-
+	
+	public float getDamageAffectedByPenetration(EntityBullet bullet, float penetrationLost, float penetrationEffectOnDamage) {
+		if(penetrationEffectOnDamage > 0 && this.penetratingPower > 0 && bullet.penetratingPower >= 0 && penetrationLost > 0) {
+			//The amount of penetration that is left in reference to the initial value
+			float penetrationLeftPercentage = 1 - (penetrationLost/this.penetratingPower);
+			
+			if(penetrationLeftPercentage < 1) {
+				//if 'penetrationEffectOnDamage' is less than 1, we increase penetrationLeftPercentage, to increase bullet damage
+				float addition = (1-penetrationLeftPercentage) * (1-penetrationEffectOnDamage);
+				
+				return (bullet.damage * (penetrationLeftPercentage + addition) );
+			}
+        }
+		return bullet.damage;
+	}
+	
 	public static BulletType getBullet(String s)
 	{
 		for(BulletType bullet : bullets)

--- a/src/main/java/com/flansmod/common/guns/BulletType.java
+++ b/src/main/java/com/flansmod/common/guns/BulletType.java
@@ -306,21 +306,6 @@ public class BulletType extends ShootableType
 		}
 	}
 	
-	public float getDamageAffectedByPenetration(EntityBullet bullet, float penetrationLost, float penetrationEffectOnDamage) {
-		if(penetrationEffectOnDamage > 0 && this.penetratingPower > 0 && bullet.penetratingPower >= 0 && penetrationLost > 0) {
-			//The amount of penetration that is left in reference to the initial value
-			float penetrationLeftPercentage = 1 - (penetrationLost/this.penetratingPower);
-			
-			if(penetrationLeftPercentage < 1) {
-				//if 'penetrationEffectOnDamage' is less than 1, we increase penetrationLeftPercentage, to increase bullet damage
-				float addition = (1-penetrationLeftPercentage) * (1-penetrationEffectOnDamage);
-				
-				return (bullet.damage * (penetrationLeftPercentage + addition) );
-			}
-        }
-		return bullet.damage;
-	}
-	
 	public static BulletType getBullet(String s)
 	{
 		for(BulletType bullet : bullets)

--- a/src/main/java/com/flansmod/common/guns/EntityBullet.java
+++ b/src/main/java/com/flansmod/common/guns/EntityBullet.java
@@ -1571,7 +1571,7 @@ public class EntityBullet extends EntityShootable implements IEntityAdditionalSp
 			float effectOnDamage = penetrationLoss.getType().getEffectOnDamage(type);
 			float loss = penetrationLoss.getLoss();
 			
-			if(effectOnDamage <= 0 || effectOnDamage > 1 || this.penetratingPower <= 0 && loss == 0) continue;
+			if(effectOnDamage <= 0 || effectOnDamage > 1 || this.penetratingPower <= 0 || loss == 0) continue;
 
 			float penetrationLostPercentage = (loss/type.penetratingPower);
 			if(penetrationLostPercentage == 0) continue;

--- a/src/main/java/com/flansmod/common/guns/EntityBullet.java
+++ b/src/main/java/com/flansmod/common/guns/EntityBullet.java
@@ -1571,7 +1571,7 @@ public class EntityBullet extends EntityShootable implements IEntityAdditionalSp
 			float effectOnDamage = penetrationLoss.getType().getEffectOnDamage(type);
 			float loss = penetrationLoss.getLoss();
 			
-			if(effectOnDamage <= 0 || effectOnDamage > 1 || this.penetratingPower <= 0 || loss == 0) continue;
+			if(effectOnDamage <= 0 || effectOnDamage > 1 || loss <= 0) continue;
 
 			float penetrationLostPercentage = (loss/type.penetratingPower);
 			if(penetrationLostPercentage == 0) continue;

--- a/src/main/java/com/flansmod/common/guns/PenetrationLoss.java
+++ b/src/main/java/com/flansmod/common/guns/PenetrationLoss.java
@@ -1,0 +1,42 @@
+package com.flansmod.common.guns;
+
+public class PenetrationLoss {
+
+	public enum PenetrationLossType {
+		PLAYER, ENTITY, BLOCK, DECAY;
+		
+		public float getEffectOnDamage(BulletType bulletType) {
+			switch(this) {
+			case BLOCK:
+				return bulletType.blockPenetrationEffectOnDamage;
+			case DECAY:
+				return bulletType.penetrationDecayEffectOnDamage;
+			case ENTITY:
+				return bulletType.entityPenetrationEffectOnDamage;
+			case PLAYER:
+				return bulletType.playerPenetrationEffectOnDamage;
+			default:
+				return 1F;
+			}
+		}
+		
+	}
+	
+	private final PenetrationLossType type;
+	
+	private final float loss;
+	
+	public PenetrationLoss(float loss, PenetrationLossType type) {
+		this.loss = loss;
+		this.type = type;
+	}
+	
+	public float getLoss() {
+		return loss;
+	}
+	
+	public PenetrationLossType getType() {
+		return type;
+	}
+	
+}

--- a/src/main/java/com/flansmod/common/guns/raytracing/PlayerHitbox.java
+++ b/src/main/java/com/flansmod/common/guns/raytracing/PlayerHitbox.java
@@ -206,7 +206,7 @@ public class PlayerHitbox {
             case LEFTARM:
             case RIGHTARM: {
                 //Calculate the hit damage
-                float hitDamage = bullet.damage * bullet.type.damageVsPlayer * damageModifier;
+                float hitDamage = bullet.getDamageAffectedByPenetration() * bullet.type.damageVsPlayer * damageModifier;
                 //Create a damage source object
                 DamageSource damagesource = bullet.owner == null ? DamageSource.generic : bullet.getBulletDamage(type == EnumHitboxType.HEAD);
                 //When the damage is 0 (such as with Nerf guns) the entityHurt Forge hook is not called, so this hacky thing is here


### PR DESCRIPTION
I think there should be a way to make bullets weaker after they penetrated some stuff. This could also be used as a great balancing factor for block penetration especially.

The way it works (block penetration as an example):
A block hit subtracts a certain amount of penetration from the bullet. This loss of penetration is used to subtract damage from the bullet. If 'blockPenetrationEffectOnDamage' is less than 1, it reduces the effect of that penetration loss by set amount.

- playerPenetrationEffectOnDamage
- entityPenetrationEffectOnDamage
- blockPenetrationEffectOnDamage
- penetrationDecayEffectOnDamage