### PR TITLE
Removed global entity IDs for Bullet and Grenade

### DIFF
--- a/src/main/java/com/flansmod/common/FlansMod.java
+++ b/src/main/java/com/flansmod/common/FlansMod.java
@@ -346,39 +346,25 @@ public class FlansMod {
         log("Loaded recipes.");
 
         //Register teams mod entities
-        EntityRegistry.registerGlobalEntityID(EntityFlagpole.class, "Flagpole", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityFlagpole.class, "Flagpole", 93, this, 40, 5, true);
-        EntityRegistry.registerGlobalEntityID(EntityFlag.class, "Flag", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityFlag.class, "Flag", 94, this, 40, 5, true);
-        EntityRegistry.registerGlobalEntityID(EntityTeamItem.class, "TeamsItem", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityTeamItem.class, "TeamsItem", 97, this, 100, 10000, true);
-        EntityRegistry.registerGlobalEntityID(EntityGunItem.class, "GunItem", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityGunItem.class, "GunItem", 98, this, 100, 20, true);
 
         //Register driveables
-        EntityRegistry.registerGlobalEntityID(EntityPlane.class, "Plane", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityPlane.class, "Plane", 90, this, 200, 3, true);
-        EntityRegistry.registerGlobalEntityID(EntityVehicle.class, "Vehicle", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityVehicle.class, "Vehicle", 95, this, 400, 10, true);
-        EntityRegistry.registerGlobalEntityID(EntitySeat.class, "Seat", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntitySeat.class, "Seat", 99, this, 250, 10, true);
-        EntityRegistry.registerGlobalEntityID(EntityWheel.class, "Wheel", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityWheel.class, "Wheel", 103, this, 200, 20, true);
-        EntityRegistry.registerGlobalEntityID(EntityParachute.class, "Parachute", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityParachute.class, "Parachute", 101, this, 40, 20, false);
-        EntityRegistry.registerGlobalEntityID(EntityMecha.class, "Mecha", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityMecha.class, "Mecha", 102, this, 250, 20, false);
 
         //Register bullets and grenades
-        EntityRegistry.registerGlobalEntityID(EntityBullet.class, "Bullet", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityBullet.class, "Bullet", 96, this, 200, 20, false);
-        EntityRegistry.registerGlobalEntityID(EntityGrenade.class, "Grenade", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityGrenade.class, "Grenade", 100, this, 40, 100, true);
 
         //Register MGs and AA guns
-        EntityRegistry.registerGlobalEntityID(EntityMG.class, "MG", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityMG.class, "MG", 91, this, 40, 5, true);
-        EntityRegistry.registerGlobalEntityID(EntityAAGun.class, "AAGun", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityAAGun.class, "AAGun", 92, this, 40, 500, false);
 
         //Register the chunk loader

--- a/src/main/java/com/flansmod/common/FlansMod.java
+++ b/src/main/java/com/flansmod/common/FlansMod.java
@@ -346,17 +346,27 @@ public class FlansMod {
         log("Loaded recipes.");
 
         //Register teams mod entities
+        EntityRegistry.registerGlobalEntityID(EntityFlagpole.class, "Flagpole", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityFlagpole.class, "Flagpole", 93, this, 40, 5, true);
+        EntityRegistry.registerGlobalEntityID(EntityFlag.class, "Flag", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityFlag.class, "Flag", 94, this, 40, 5, true);
+        EntityRegistry.registerGlobalEntityID(EntityTeamItem.class, "TeamsItem", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityTeamItem.class, "TeamsItem", 97, this, 100, 10000, true);
+        EntityRegistry.registerGlobalEntityID(EntityGunItem.class, "GunItem", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityGunItem.class, "GunItem", 98, this, 100, 20, true);
 
         //Register driveables
+        EntityRegistry.registerGlobalEntityID(EntityPlane.class, "Plane", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityPlane.class, "Plane", 90, this, 200, 3, true);
+        EntityRegistry.registerGlobalEntityID(EntityVehicle.class, "Vehicle", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityVehicle.class, "Vehicle", 95, this, 400, 10, true);
+        EntityRegistry.registerGlobalEntityID(EntitySeat.class, "Seat", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntitySeat.class, "Seat", 99, this, 250, 10, true);
+        EntityRegistry.registerGlobalEntityID(EntityWheel.class, "Wheel", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityWheel.class, "Wheel", 103, this, 200, 20, true);
+        EntityRegistry.registerGlobalEntityID(EntityParachute.class, "Parachute", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityParachute.class, "Parachute", 101, this, 40, 20, false);
+        EntityRegistry.registerGlobalEntityID(EntityMecha.class, "Mecha", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityMecha.class, "Mecha", 102, this, 250, 20, false);
 
         //Register bullets and grenades
@@ -364,7 +374,9 @@ public class FlansMod {
         EntityRegistry.registerModEntity(EntityGrenade.class, "Grenade", 100, this, 40, 100, true);
 
         //Register MGs and AA guns
+        EntityRegistry.registerGlobalEntityID(EntityMG.class, "MG", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityMG.class, "MG", 91, this, 40, 5, true);
+        EntityRegistry.registerGlobalEntityID(EntityAAGun.class, "AAGun", EntityRegistry.findGlobalUniqueEntityId());
         EntityRegistry.registerModEntity(EntityAAGun.class, "AAGun", 92, this, 40, 500, false);
 
         //Register the chunk loader


### PR DESCRIPTION
## Description of changes
Removed global entity IDs for "Bullet" and "Grenade". Global IDs for entities are useless and cause compatibility issues with other mods that use the same names like Star Wars ACW Survival (crashes at startup because of "Bullet" & "Grenade" registered twice)

## Intended usage in Content Packs/Users of the mod
Users of the mod would no longer need to worry about using Flan's Mod with other mods like Star Wars ACW Survival.

## Compatibility
Better compatibility with other mods. When loading an already existing World that used previously Flan's Mod, pre-existing bullets and grenades would despawn, but I think this does not matter really anyway. I did not remove other global IDs since there are no other known conflicts yet and to make sure existing Driveables and other entites do not despawn.
