### PR TITLE
Bug Fix: Bullets from Flan's Mod are no longer being blocked by any kind of Projectiles

### DIFF
--- a/src/main/java/com/flansmod/common/guns/EntityBullet.java
+++ b/src/main/java/com/flansmod/common/guns/EntityBullet.java
@@ -32,6 +32,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.IProjectile;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.item.EntityXPOrb;
 import net.minecraft.entity.player.EntityPlayer;
@@ -536,7 +537,7 @@ public class EntityBullet extends EntityShootable implements IEntityAdditionalSp
                 }
             } else {
                 Entity entity = (Entity) obj;
-                if (entity != this && entity != owner && !entity.isDead && !(entity instanceof EntityItem) && !(entity instanceof EntityXPOrb) && !(entity instanceof EntityArrow) &&
+                if (entity != owner && !entity.isDead && !(entity instanceof EntityBullet) && !(entity instanceof EntityItem) && !(entity instanceof IProjectile) &&
                         (!entity.getClass().toString().contains("flansmod.") || entity instanceof EntityAAGun || entity instanceof EntityGrenade)
                         && !entity.getClass().toString().contains("holographicdisplays") && !entity.getClass().toString().contains("EntityScent")
                         && !(entity instanceof EntityLivingBase && ((EntityLivingBase) entity).getHealth() == 0.0)) {


### PR DESCRIPTION
## Description of changes
When the EntityBullet checks for potential hits, some entites are excluded so that they can be passed through/ignored. This change aims at expanding the list of these entites.
1. any class implementing IProjectile needs to be excluded since many other mods use IProjectile for their projectiles.
This was done by replacing `!(entity instanceof EntityXPOrb) && !(entity instanceof EntityArrow)` by `!(entity instanceof IProjectile)` since these two already implement IProjectile.
2. To make sure potential subclasses of EntityBullet are excluded (I used a subclass in my NPC vehicles mod) `entity != this` was replaced by `!(entity instanceof EntityBullet)` which is a broader clause that is not entirely covered by `!entity.getClass().toString().contains("flansmod.")` since subclasses of EntityBullet can exist outside of the "flansmod" package.

## Intended usage in Content Packs/Users of the mod
Nothing changed here.

## Compatibility
More Stability and Better Compatibility with other mods by taking more use cases with projectiles into account.
