### PR TITLE
Small reload cancel improvements

### DIFF
--- a/src/main/java/com/flansmod/client/model/RenderGun.java
+++ b/src/main/java/com/flansmod/client/model/RenderGun.java
@@ -850,10 +850,10 @@ public class RenderGun implements IItemRenderer {
 			}
 
 			// Check to see if the ammo should be rendered first
-			if ((anim == EnumAnimationType.END_LOADED || anim == EnumAnimationType.BACK_LOADED) && empty) {
+			if ((anim == EnumAnimationType.END_LOADED || anim == EnumAnimationType.BACK_LOADED) && empty && !animations.reloading) {
 				shouldRender = false;
 			}
-
+			
 			// If it should be rendered, do the transformations required
 			if (shouldRender && animations.reloading && Minecraft.getMinecraft().gameSettings.thirdPersonView == 0)
 			{

--- a/src/main/java/com/flansmod/client/model/RenderGun.java
+++ b/src/main/java/com/flansmod/client/model/RenderGun.java
@@ -694,7 +694,7 @@ public class RenderGun implements IItemRenderer {
 		// Render the pump-action handle
 		if (pumpAttachment == null)
 		{
-			GL11.glPushMatrix();
+		        GL11.glPushMatrix();
 			{
 				GL11.glTranslatef(-(1 - Math.abs(animations.lastPumped + (animations.pumped - animations.lastPumped) * smoothing)) * model.pumpHandleDistance, 0F, 0F);
 				model.renderPump(f);

--- a/src/main/java/com/flansmod/common/PlayerData.java
+++ b/src/main/java/com/flansmod/common/PlayerData.java
@@ -172,11 +172,11 @@ public class PlayerData
 	}
 	
 	public void queueReload(ItemStack gunStack, int reloadSlot, float reloadTime,
-			World world, Entity entity, IInventory inventory, boolean creative, boolean combineAmmoOnReload, boolean ammoToUpperInventory) {		
+			World world, Entity entity, IInventory inventory, boolean creative, boolean forceReload, boolean combineAmmoOnReload, boolean ammoToUpperInventory) {		
 		this.gunToReload = gunStack;
 		this.reloadSlot = reloadSlot;
 		
-		queuedReload = new QueuedReload(gunStack, reloadTime, world, entity, inventory, creative, combineAmmoOnReload, ammoToUpperInventory);
+		queuedReload = new QueuedReload(gunStack, reloadTime, world, entity, inventory, creative, forceReload, combineAmmoOnReload, ammoToUpperInventory);
 	}
 	
 	public boolean isHoldingGunToReload(EntityPlayer player) {

--- a/src/main/java/com/flansmod/common/PlayerData.java
+++ b/src/main/java/com/flansmod/common/PlayerData.java
@@ -144,7 +144,7 @@ public class PlayerData
                     gunAnimationLeft.reloading = false;
                 }
             } else if(!player.worldObj.isRemote && queuedReload != null) {
-                if (queuedReload.getReloadTime() > 0) {
+                if (queuedReload.getReloadTime() > 1) {
                     queuedReload.decrementReloadTime();
                 } else {
                     queuedReload.doReload();

--- a/src/main/java/com/flansmod/common/PlayerData.java
+++ b/src/main/java/com/flansmod/common/PlayerData.java
@@ -66,6 +66,7 @@ public class PlayerData
 	public int burstRoundsRemainingLeft = 0, burstRoundsRemainingRight = 0;
 
 	public ItemStack gunToReload;
+	public int reloadSlot;
 	private QueuedReload queuedReload;
 	
 	public boolean isAmmoEmpty;
@@ -153,7 +154,7 @@ public class PlayerData
         } 
 		
 		
-		//Handle minigun speed
+        //Handle minigun speed
 		if(isShootingRight && !reloadingRight)
 			minigunSpeed += 2F; 
 		minigunSpeed *= 0.9F;
@@ -170,16 +171,18 @@ public class PlayerData
 		snapshots[0] = new PlayerSnapshot(player);
 	}
 	
-	public void queueReload(ItemStack gunStack, float reloadTime,
+	public void queueReload(ItemStack gunStack, int reloadSlot, float reloadTime,
 			World world, Entity entity, IInventory inventory, boolean creative, boolean combineAmmoOnReload, boolean ammoToUpperInventory) {		
 		this.gunToReload = gunStack;
+		this.reloadSlot = reloadSlot;
+		
 		queuedReload = new QueuedReload(gunStack, reloadTime, world, entity, inventory, creative, combineAmmoOnReload, ammoToUpperInventory);
 	}
 	
 	public boolean isHoldingGunToReload(EntityPlayer player) {
     	ItemStack heldItem = player.getHeldItem();
 
-    	return !(heldItem == null || gunToReload != heldItem);
+    	return !(heldItem == null || gunToReload.getItem() != heldItem.getItem() || player.inventory.currentItem != reloadSlot);
     }
 	
 	public void clientTick(EntityPlayer player)

--- a/src/main/java/com/flansmod/common/guns/ItemGun.java
+++ b/src/main/java/com/flansmod/common/guns/ItemGun.java
@@ -1319,7 +1319,8 @@ public class ItemGun extends Item implements IPaintableItem, IGunboxDescriptiona
                 if (bestSlot != -1) {  
                 	boolean isPlayer = entity instanceof EntityPlayer; 
                 	if(isPlayer && onlyCheckIfPlayerCanReload) {
-                		PlayerHandler.getPlayerData((EntityPlayer) entity).queueReload(gunStack, reloadTime, world, entity, inventory, creative, combineAmmoOnReload, ammoToUpperInventory);
+                	    EntityPlayer player = (EntityPlayer) entity;               	    
+                		PlayerHandler.getPlayerData(player).queueReload(gunStack, player.inventory.currentItem, reloadTime, world, entity, inventory, creative, combineAmmoOnReload, ammoToUpperInventory);
                 		return true;
                 	}
                 	

--- a/src/main/java/com/flansmod/common/guns/ItemGun.java
+++ b/src/main/java/com/flansmod/common/guns/ItemGun.java
@@ -1280,7 +1280,7 @@ public class ItemGun extends Item implements IPaintableItem, IGunboxDescriptiona
             return false;
         //Melee cannot be reloaded
         if (gunType.ammo.isEmpty())
-            return false;
+            return false;        
         //If you cannot reload half way through a clip, reject the player for trying to do so
         if (forceReload && !gunType.canForceReload)
             return false;
@@ -1321,7 +1321,7 @@ public class ItemGun extends Item implements IPaintableItem, IGunboxDescriptiona
                 	boolean isPlayer = entity instanceof EntityPlayer; 
                 	if(isPlayer && onlyCheckIfPlayerCanReload) {
                 	    EntityPlayer player = (EntityPlayer) entity;               	    
-                		PlayerHandler.getPlayerData(player).queueReload(gunStack, player.inventory.currentItem, reloadTime, world, entity, inventory, creative, combineAmmoOnReload, ammoToUpperInventory);
+                		PlayerHandler.getPlayerData(player).queueReload(gunStack, player.inventory.currentItem, reloadTime, world, entity, inventory, creative, forceReload, combineAmmoOnReload, ammoToUpperInventory);
                 		return true;
                 	}
                 	

--- a/src/main/java/com/flansmod/common/guns/ItemGun.java
+++ b/src/main/java/com/flansmod/common/guns/ItemGun.java
@@ -378,13 +378,13 @@ public class ItemGun extends Item implements IPaintableItem, IGunboxDescriptiona
                         GunType offHandGunType = ((ItemGun) offHandGunStack.getItem()).type;
                         if (offHandGunType.usableByPlayers) {
                             //If we are using a burst mode gun, and there is burst left to be done, try to do it
-                            if (offHandGunType.getFireMode(offHandGunStack) == EnumFireMode.BURST && data.burstRoundsRemainingLeft > 0) {
+                            if (offHandGunType.getFireMode(offHandGunStack) == EnumFireMode.BURST && data.burstRoundsRemainingLeft > 0) {                            
                                 if (clientSideShoot(player, offHandGunStack, offHandGunType, true))
                                     player.inventory.setInventorySlotContents(data.offHandGunSlot - 1, null);
                             } else {
                                 //Send packet when firing a semi or starting to fire a full
                                 if (leftMouseHeld && !lastLeftMouseHeld) {
-                                    FlansMod.getPacketHandler().sendToServer(new PacketGunFire(true, true, player.rotationYaw, player.rotationPitch));
+                                    FlansMod.getPacketHandler().sendToServer(new PacketGunFire(true, true, player.rotationYaw, player.rotationPitch));                                   
                                     if (clientSideShoot(player, offHandGunStack, offHandGunType, true))
                                         player.inventory.setInventorySlotContents(data.offHandGunSlot - 1, null);
                                 }
@@ -392,7 +392,7 @@ public class ItemGun extends Item implements IPaintableItem, IGunboxDescriptiona
                                 {
                                     FlansMod.getPacketHandler().sendToServer(new PacketGunFire(true, false, player.rotationYaw, player.rotationPitch));
                                 }
-                                if ((offHandGunType.getFireMode(offHandGunStack) == EnumFireMode.FULLAUTO || offHandGunType.getFireMode(offHandGunStack) == EnumFireMode.MINIGUN) && leftMouseHeld) {
+                                if ((offHandGunType.getFireMode(offHandGunStack) == EnumFireMode.FULLAUTO || offHandGunType.getFireMode(offHandGunStack) == EnumFireMode.MINIGUN) && leftMouseHeld) {                                    
                                     if (clientSideShoot(player, offHandGunStack, offHandGunType, true)) {
                                         player.inventory.setInventorySlotContents(data.offHandGunSlot - 1, null);
                                     }
@@ -624,6 +624,7 @@ public class ItemGun extends Item implements IPaintableItem, IGunboxDescriptiona
 
         // ShootTime <= 0 and player is sprinting zoomed or player is not sprinting, or the player can hipFireWhileSprinting
         boolean canActuallyHipFire = (gunType.hipFireWhileSprinting != 2) && !(gunType.hipFireWhileSprinting == 0 && FlansMod.disableSprintHipFireByDefault);
+        
         if (FlansModClient.switchTime <= 0 && FlansModClient.shootTime(left) <= 0 && ((sprinting && isScoped) || !sprinting || canActuallyHipFire) && !(player.ridingEntity instanceof EntitySeat)) {
 //			boolean onLastBullet = false;
             boolean hasAmmo = false;
@@ -659,7 +660,7 @@ public class ItemGun extends Item implements IPaintableItem, IGunboxDescriptiona
                 int casingDelay = gunType.model == null ? 0 : gunType.model.casingDelay;
                 float hammerAngle = gunType.model == null ? 0 : gunType.model.hammerAngle;
                 float althammerAngle = gunType.model == null ? 0 : gunType.model.althammerAngle;
-
+                
 //				animations.onGunEmpty(onLastBullet);
                 animations.doShoot(pumpDelay, pumpTime, hammerDelay, hammerAngle, althammerAngle, casingDelay);
                 if (type.useFancyRecoil) {

--- a/src/main/java/com/flansmod/common/guns/QueuedReload.java
+++ b/src/main/java/com/flansmod/common/guns/QueuedReload.java
@@ -14,6 +14,7 @@ public class QueuedReload {
 	private Entity entity;
 	private IInventory inventory;
 	private boolean creative, combineAmmoOnReload, ammoToUpperInventory;
+	private boolean forceReload;
 	
 	public final ItemStack gunStack;
 	
@@ -22,7 +23,7 @@ public class QueuedReload {
 	
 	
 	public QueuedReload(ItemStack gunStack, float reloadTime, World world,
-			Entity entity, IInventory inventory, boolean creative, boolean combineAmmoOnReload, boolean ammoToUpperInventory) {
+			Entity entity, IInventory inventory, boolean creative, boolean forceReload, boolean combineAmmoOnReload, boolean ammoToUpperInventory) {
 		this.gunStack = gunStack;
 		
 		this.reloadTime = reloadTime;
@@ -31,6 +32,7 @@ public class QueuedReload {
 		this.entity = entity;
 		this.inventory = inventory;
 		this.creative = creative;
+		this.forceReload = forceReload;
 		this.combineAmmoOnReload = combineAmmoOnReload;
 		this.ammoToUpperInventory = ammoToUpperInventory;
 	}
@@ -48,7 +50,7 @@ public class QueuedReload {
 		didReload = true;
 		ItemGun gun = ((ItemGun)gunStack.getItem());
 		
-		gun.reload(gunStack, gun.type, world, entity, inventory, creative, true, combineAmmoOnReload, ammoToUpperInventory, reloadTime, false);
+		gun.reload(gunStack, gun.type, world, entity, inventory, creative, forceReload, combineAmmoOnReload, ammoToUpperInventory, reloadTime, false);
 	}
 	
 }

--- a/src/main/java/com/flansmod/common/network/PacketReload.java
+++ b/src/main/java/com/flansmod/common/network/PacketReload.java
@@ -159,10 +159,11 @@ public class PacketReload extends PacketBase {
         
         if (stack != null && stack.getItem() instanceof ItemGun) {
             GunType type = ((ItemGun) stack.getItem()).type;
-            if (left)
-                FlansModClient.shootTimeLeft += (int) type.getReloadTime(stack);
-            else FlansModClient.shootTimeRight += (int) type.getReloadTime(stack);
 
+            if (left)
+                FlansModClient.shootTimeLeft += reloadTime;
+            else FlansModClient.shootTimeRight += reloadTime;  
+            
             //Apply animations
             GunAnimations animations = null;
             if (left) {

--- a/src/main/java/com/flansmod/common/network/PacketReload.java
+++ b/src/main/java/com/flansmod/common/network/PacketReload.java
@@ -159,7 +159,7 @@ public class PacketReload extends PacketBase {
         
         if (stack != null && stack.getItem() instanceof ItemGun) {
             GunType type = ((ItemGun) stack.getItem()).type;
-
+            
             if (left)
                 FlansModClient.shootTimeLeft += reloadTime;
             else FlansModClient.shootTimeRight += reloadTime;  

--- a/src/main/java/com/flansmod/common/network/PacketReload.java
+++ b/src/main/java/com/flansmod/common/network/PacketReload.java
@@ -185,7 +185,9 @@ public class PacketReload extends PacketBase {
             int chargeDelay = type.model == null ? 0 : type.model.chargeDelayAfterReload;
             int chargeTime = type.model == null ? 1 : type.model.chargeTime;
                       
-            PlayerHandler.getPlayerData(clientPlayer, Side.CLIENT).gunToReload = stack;
+            PlayerData playerData = PlayerHandler.getPlayerData(clientPlayer, Side.CLIENT);
+            playerData.gunToReload = stack;
+            playerData.reloadSlot = clientPlayer.inventory.currentItem;
             animations.doReload(reloadTime, pumpDelay, pumpTime, chargeDelay, chargeTime, amount, singlesReload);
             
             


### PR DESCRIPTION
Changes:
- fixed bug where ammo wouldn't render for empty guns (e.g. RPGs)
- reload is now cancelled if slot is changed or item type is different


