### PR TITLE
Cancel reload sound when cancelling a reload

### DIFF
--- a/src/main/java/com/flansmod/client/FlansModClient.java
+++ b/src/main/java/com/flansmod/client/FlansModClient.java
@@ -1,5 +1,10 @@
 package com.flansmod.client;
 
+import java.util.HashMap;
+
+import org.lwjgl.input.Mouse;
+import org.lwjgl.opengl.GL11;
+
 import com.flansmod.api.IControllable;
 import com.flansmod.client.gui.GuiDriveableController;
 import com.flansmod.client.gui.GuiTeamScores;
@@ -16,6 +21,7 @@ import com.flansmod.common.network.PacketTeamInfo.PlayerScoreData;
 import com.flansmod.common.teams.Team;
 import com.flansmod.common.types.InfoType;
 import com.mojang.authlib.minecraft.MinecraftProfileTexture.Type;
+
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.common.ObfuscationReflectionHelper;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -24,6 +30,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.audio.ISound;
 import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.entity.EntityOtherPlayerMP;
 import net.minecraft.client.entity.EntityPlayerSP;
@@ -149,6 +156,8 @@ public class FlansModClient extends FlansMod {
     
     public static boolean combineAmmoOnReload = true;
     public static boolean ammoToUpperInventoryOnReload = false;
+    
+    public static HashMap<String, ISound> reloadSound = new HashMap<>();
     
     
     public void load() {

--- a/src/main/java/com/flansmod/common/PlayerData.java
+++ b/src/main/java/com/flansmod/common/PlayerData.java
@@ -10,6 +10,7 @@ import com.flansmod.common.guns.GunType;
 import com.flansmod.common.guns.ItemGun;
 import com.flansmod.common.guns.QueuedReload;
 import com.flansmod.common.guns.raytracing.PlayerSnapshot;
+import com.flansmod.common.network.PacketCancelReloadSound;
 import com.flansmod.common.network.PacketSelectOffHandGun;
 import com.flansmod.common.teams.PlayerClass;
 import com.flansmod.common.teams.Team;
@@ -129,9 +130,6 @@ public class PlayerData
                 this.shootTimeLeft = 0;
                 this.shootTimeRight = 0;
 
-                queuedReload = null;
-                gunToReload = null;
-
                 if(player.worldObj.isRemote) {
                     FlansModClient.shootTimeRight = 0;
                     FlansModClient.shootTimeLeft = 0;
@@ -142,7 +140,14 @@ public class PlayerData
                     GunAnimations gunAnimationLeft = FlansModClient.getGunAnimations(player, true);
                     gunAnimationLeft.reloadAnimationProgress = 0F;
                     gunAnimationLeft.reloading = false;
+                } else {
+                    GunType type = ((ItemGun)gunToReload.getItem()).type;
+                    
+                    FlansMod.getPacketHandler().sendToAllAround(new PacketCancelReloadSound(player.getCommandSenderName()), player.posX, player.posY, player.posZ, type.reloadSoundRange, player.dimension);
                 }
+                
+                queuedReload = null;
+                gunToReload = null;
             } else if(!player.worldObj.isRemote && queuedReload != null) {
                 if (queuedReload.getReloadTime() > 1) {
                     queuedReload.decrementReloadTime();

--- a/src/main/java/com/flansmod/common/guns/ItemGun.java
+++ b/src/main/java/com/flansmod/common/guns/ItemGun.java
@@ -1207,7 +1207,7 @@ public class ItemGun extends Item implements IPaintableItem, IGunboxDescriptiona
 
                     if (soundToPlay != null) {
                         PacketPlaySound.sendSoundPacket(entityplayer.posX, entityplayer.posY, entityplayer.posZ,
-                                type.reloadSoundRange, entityplayer.dimension, soundToPlay, true);
+                                type.reloadSoundRange, entityplayer.dimension, soundToPlay, true, false, entityplayer.getCommandSenderName());
                     }
                 } else if ((gunType.clickSoundOnEmpty != null) && canClick) {
                     PacketPlaySound.sendSoundPacket(entityplayer.posX, entityplayer.posY, entityplayer.posZ, type.reloadSoundRange, entityplayer.dimension, gunType.clickSoundOnEmpty, true);

--- a/src/main/java/com/flansmod/common/network/PacketCancelReloadSound.java
+++ b/src/main/java/com/flansmod/common/network/PacketCancelReloadSound.java
@@ -1,0 +1,52 @@
+package com.flansmod.common.network;
+
+import com.flansmod.client.FlansModClient;
+import com.flansmod.common.FlansMod;
+import com.flansmod.common.PlayerData;
+import com.flansmod.common.PlayerHandler;
+
+import cpw.mods.fml.relauncher.Side;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.audio.ISound;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import cpw.mods.fml.common.network.ByteBufUtils;
+
+public class PacketCancelReloadSound extends PacketBase {
+	
+	public String playerWhoReloaded;
+	
+	public PacketCancelReloadSound() { }
+			
+	public PacketCancelReloadSound(String playerWhoReloaded) {
+		this.playerWhoReloaded = playerWhoReloaded;
+	}
+
+	@Override
+	public void encodeInto(ChannelHandlerContext ctx, ByteBuf data) {
+		writeUTF(data, playerWhoReloaded);
+	}
+
+	@Override
+	public void decodeInto(ChannelHandlerContext ctx, ByteBuf data) {
+	    playerWhoReloaded = readUTF(data);
+	}
+
+	@Override
+	public void handleServerSide(EntityPlayerMP playerEntity)  {
+	    FlansMod.log("Received cancel reload sound packet on server. Skipping.");
+	}
+
+	@Override
+	public void handleClientSide(EntityPlayer clientPlayer) {
+		ISound reloadSound = FlansModClient.reloadSound.remove(playerWhoReloaded);
+	    if(reloadSound == null) return;
+		
+	    Minecraft.getMinecraft().getSoundHandler().stopSound(reloadSound);	    
+	}
+
+}

--- a/src/main/java/com/flansmod/common/network/PacketHandler.java
+++ b/src/main/java/com/flansmod/common/network/PacketHandler.java
@@ -173,7 +173,7 @@ public class PacketHandler extends MessageToMessageCodec<FMLProxyPacket, PacketB
         registerPacket(PacketSendPlayerClasses.class);
         registerPacket(PacketRespawnFinished.class);
         registerPacket(PacketChangeZoom.class);
-
+        registerPacket(PacketCancelReloadSound.class);
     }
 
     /**

--- a/src/main/java/com/flansmod/common/network/PacketReload.java
+++ b/src/main/java/com/flansmod/common/network/PacketReload.java
@@ -140,7 +140,7 @@ public class PacketReload extends PacketBase {
                     soundToPlay = type.reloadSound;
 
                 if (soundToPlay != null && reloadTime>0)
-                    PacketPlaySound.sendSoundPacket(playerEntity.posX, playerEntity.posY, playerEntity.posZ, type.reloadSoundRange, playerEntity.dimension, soundToPlay, true);
+                    PacketPlaySound.sendSoundPacket(playerEntity.posX, playerEntity.posY, playerEntity.posZ, type.reloadSoundRange, playerEntity.dimension, soundToPlay, true, false, playerEntity.getCommandSenderName());
             }
         }
     }


### PR DESCRIPTION
Thanks to SecretAgent12's message on discord, I cobbled together a way to cancel reload sounds.

When a reload sound packet is sent, the player who is reloading is put in a hashmap with the reload sound.
And when that player cancels their reload, a cancel reload sound packet is sent to all players around, to cancel the sound.