### PR TITLE
Minigun barrel rotation speed animation config

### DIFF
--- a/src/main/java/com/flansmod/client/model/ModelGun.java
+++ b/src/main/java/com/flansmod/client/model/ModelGun.java
@@ -42,6 +42,7 @@ public class ModelGun extends ModelBase
 	public ModelRendererTurbo[] althammerModel = new ModelRendererTurbo[0];
 	/** The point about which the minigun barrel rotates. Rotation is along the line of the gun through this point */
 	public Vector3f minigunBarrelOrigin = new Vector3f();
+	public float minigunBarrelRotationSpeed = 1F;
 
 	//These designate the locations of 3D attachment models on the gun
 	public Vector3f barrelAttachPoint = new Vector3f();

--- a/src/main/java/com/flansmod/client/model/ModelGun.java
+++ b/src/main/java/com/flansmod/client/model/ModelGun.java
@@ -42,8 +42,8 @@ public class ModelGun extends ModelBase
 	public ModelRendererTurbo[] althammerModel = new ModelRendererTurbo[0];
 	/** The point about which the minigun barrel rotates. Rotation is along the line of the gun through this point */
 	public Vector3f minigunBarrelOrigin = new Vector3f();
-	public Vector3f minigunBarrelRotationSpeed = new Vector3f(1F, 0F, 0F);
-	public float minigunBarrelRotationSpeed = 1F;
+	public Vector3f minigunBarrelSpinDirection = new Vector3f(1F, 0F, 0F);
+	public float minigunBarrelSpinSpeed = 1F;
 
 	//These designate the locations of 3D attachment models on the gun
 	public Vector3f barrelAttachPoint = new Vector3f();

--- a/src/main/java/com/flansmod/client/model/ModelGun.java
+++ b/src/main/java/com/flansmod/client/model/ModelGun.java
@@ -42,7 +42,8 @@ public class ModelGun extends ModelBase
 	public ModelRendererTurbo[] althammerModel = new ModelRendererTurbo[0];
 	/** The point about which the minigun barrel rotates. Rotation is along the line of the gun through this point */
 	public Vector3f minigunBarrelOrigin = new Vector3f();
-	public float minigunBarrelRotationSpeed = 2F;
+	public Vector3f minigunBarrelRotationSpeed = new Vector3f(1F, 0F, 0F);
+	public float minigunBarrelRotationSpeed = 1F;
 
 	//These designate the locations of 3D attachment models on the gun
 	public Vector3f barrelAttachPoint = new Vector3f();

--- a/src/main/java/com/flansmod/client/model/ModelGun.java
+++ b/src/main/java/com/flansmod/client/model/ModelGun.java
@@ -42,7 +42,7 @@ public class ModelGun extends ModelBase
 	public ModelRendererTurbo[] althammerModel = new ModelRendererTurbo[0];
 	/** The point about which the minigun barrel rotates. Rotation is along the line of the gun through this point */
 	public Vector3f minigunBarrelOrigin = new Vector3f();
-	public float minigunBarrelRotationSpeed = 1F;
+	public float minigunBarrelRotationSpeed = 2F;
 
 	//These designate the locations of 3D attachment models on the gun
 	public Vector3f barrelAttachPoint = new Vector3f();

--- a/src/main/java/com/flansmod/client/model/RenderGun.java
+++ b/src/main/java/com/flansmod/client/model/RenderGun.java
@@ -670,7 +670,7 @@ public class RenderGun implements IItemRenderer {
 		{
 			GL11.glPushMatrix();
 			GL11.glTranslatef(model.minigunBarrelOrigin.x, model.minigunBarrelOrigin.y, model.minigunBarrelOrigin.z);
-			GL11.glRotatef(animations.minigunBarrelRotation * model.minigunBarrelRotationSpeed, 1F, 0F, 0F);
+			GL11.glRotatef(animations.minigunBarrelRotation, 1F, 0F, 0F);
 			GL11.glTranslatef(-model.minigunBarrelOrigin.x, -model.minigunBarrelOrigin.y, -model.minigunBarrelOrigin.z);
 			model.renderMinigunBarrel(f);
 			GL11.glPopMatrix();

--- a/src/main/java/com/flansmod/client/model/RenderGun.java
+++ b/src/main/java/com/flansmod/client/model/RenderGun.java
@@ -670,7 +670,7 @@ public class RenderGun implements IItemRenderer {
 		{
 			GL11.glPushMatrix();
 			GL11.glTranslatef(model.minigunBarrelOrigin.x, model.minigunBarrelOrigin.y, model.minigunBarrelOrigin.z);
-			GL11.glRotatef(animations.minigunBarrelRotation, 1F, 0F, 0F);
+			GL11.glRotatef(animations.minigunBarrelRotation * model.minigunBarrelRotationSpeed, 1F, 0F, 0F);
 			GL11.glTranslatef(-model.minigunBarrelOrigin.x, -model.minigunBarrelOrigin.y, -model.minigunBarrelOrigin.z);
 			model.renderMinigunBarrel(f);
 			GL11.glPopMatrix();

--- a/src/main/java/com/flansmod/client/model/RenderGun.java
+++ b/src/main/java/com/flansmod/client/model/RenderGun.java
@@ -670,7 +670,7 @@ public class RenderGun implements IItemRenderer {
 		{
 			GL11.glPushMatrix();
 			GL11.glTranslatef(model.minigunBarrelOrigin.x, model.minigunBarrelOrigin.y, model.minigunBarrelOrigin.z);
-			GL11.glRotatef(animations.minigunBarrelRotation * model.minigunBarrelRotationSpeed, model.minigunBarrelRotation.x, model.minigunBarelRotation.y, model.minigunBarrelRotation.z);
+			GL11.glRotatef(animations.minigunBarrelRotation * model.minigunBarrelSpinSpeed, model.minigunBarrelSpinDirection.x, model.minigunBarrelSpinDirection.y, model.minigunBarrelSpinDirection.z);
 			GL11.glTranslatef(-model.minigunBarrelOrigin.x, -model.minigunBarrelOrigin.y, -model.minigunBarrelOrigin.z);
 			model.renderMinigunBarrel(f);
 			GL11.glPopMatrix();

--- a/src/main/java/com/flansmod/client/model/RenderGun.java
+++ b/src/main/java/com/flansmod/client/model/RenderGun.java
@@ -670,7 +670,7 @@ public class RenderGun implements IItemRenderer {
 		{
 			GL11.glPushMatrix();
 			GL11.glTranslatef(model.minigunBarrelOrigin.x, model.minigunBarrelOrigin.y, model.minigunBarrelOrigin.z);
-			GL11.glRotatef(animations.minigunBarrelRotation, 1F, 0F, 0F);
+			GL11.glRotatef(animations.minigunBarrelRotation * model.minigunBarrelRotationSpeed, model.minigunBarrelRotation.x, model.minigunBarelRotation.y, model.minigunBarrelRotation.z);
 			GL11.glTranslatef(-model.minigunBarrelOrigin.x, -model.minigunBarrelOrigin.y, -model.minigunBarrelOrigin.z);
 			model.renderMinigunBarrel(f);
 			GL11.glPopMatrix();


### PR DESCRIPTION
## Description of changes
Added animation modifier to change visual rotation speed of minigun barrels.

## Intended usage in Content Packs/Users of the mod
Config in gun model java (minigunBarrelRotationSpeed).

## Compatibility
Will not affect existing behaviour, including time until the minigun starts shooting.

Default speed =1 which is same rotation speed as present.

## Other
This animation setting needs to be added to the GunType model setting overrides too.

Note I haven't actually tested this, it's just an example for xdeadstokex to review.
